### PR TITLE
Read debug mode settings from environment variable

### DIFF
--- a/uppercounty/settings.py
+++ b/uppercounty/settings.py
@@ -46,7 +46,7 @@ TEMPLATE_DIRS = (
 SECRET_KEY = os.environ.get('SECRET_KEY')
 
 # SECURITY WARNING: don't run with debug turned on in production!
-DEBUG = False
+DEBUG = os.environ.get('DEBUG')
 
 # TEMPLATE_DEBUG = True
 


### PR DESCRIPTION
Got tired of manually changing debug settings to run tests locally. Changing the configuration file to grab debug mode settings from environment variables.

You can set this automatically in virtualenv when you activate your environment. In my `~/.virtuanenvs/uppercounty/bin/postactivate` file, I have

```bash
export SECRET_KEY=test
export DEBUG=True
```