### PR TITLE
Make date of swim record optional

### DIFF
--- a/web/models.py
+++ b/web/models.py
@@ -213,15 +213,18 @@ class SwimRecord(models.Model):
     swimmer_team = models.CharField(blank=True, max_length=4,
                                     choices=TEAM_CHOICES)
     time = models.CharField(max_length=9)
-    date = models.DateField()
+    date = models.DateField(blank=True, null=True)
     pool = models.CharField(blank=True, max_length=4, choices=TEAM_CHOICES)
 
     def __unicode__(self):
-        return (dict(self.RECORD_TYPE_CHOICES).get(self.record_type) +
-                " Record for Swimmers=[" + self.swimmer_name + "] of team=[" +
-                self.swimmer_team + "] Event=[#" + str(self.event_number) + " "
-                + self.event_name + "] on " + self.date.strftime('%Y-%m-%d') +
-                " at pool=[" + self.pool + "] with time " + self.time)
+        result = (dict(self.RECORD_TYPE_CHOICES).get(self.record_type) +
+                  " Record for Swimmers=[" + self.swimmer_name + "] of team=["
+                  + self.swimmer_team + "] Event=[#" + str(self.event_number)
+                  + " " + self.event_name + "] on")
+        if (self.date):
+            result += " " + self.date.strftime('%Y-%m-%d')
+        result += " at pool=[" + self.pool + "] with time " + self.time
+        return result
 
     def __str__(self):
         return unicode(self).encode('utf-8')

--- a/web/templates/web/records.html
+++ b/web/templates/web/records.html
@@ -27,7 +27,7 @@
               <td>{{ instance.event_number }}</td>
               <td>{{ instance.event_name }}</td>
               <td>{{ instance.swimmer_name }}</td>
-              <td>{{ instance.date }}</td>
+              <td>{% if instance.date %}{{ instance.date }}{% endif %}</td>
               <td>{{ instance.time }}</td>
               <td><abbr title="{{ instance.get_pool_display }}">{{ instance.pool }}</abbr></td>
             </tr>
@@ -56,7 +56,7 @@
               <td>{{ instance.event_name }}</td>
               <td>{{ instance.swimmer_name }}</td>
               <td><abbr title="{{ instance.get_swimmer_team_display }}">{{ instance.swimmer_team }}</abbr></td>
-              <td>{{ instance.date }}</td>
+              <td>{% if instance.date %}{{ instance.date }}{% endif %}</td>
               <td>{{ instance.time }}</td>
             </tr>
             {% endfor %}


### PR DESCRIPTION
An old pool record does not have a date, but still needs to be entered
into the database.