### PR TITLE
Add pystache to requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,5 +5,6 @@ Django==1.8.2
 django-storages==1.1.8
 gunicorn==19.3.0
 psycopg2==2.6
+pystache==0.5.4
 static3==0.6.1
 wheel==0.24.0


### PR DESCRIPTION
The Heroku dyno crashes without pystache installed.